### PR TITLE
Add denoise & cleanup features

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax = docker/dockerfile:1.1-experimental
 FROM alpine
 
-RUN apk --update --no-cache add git bash py3-pip openssh
+RUN apk --update --no-cache add git bash py3-pip openssh github-cli
 
 RUN apk add --no-cache -X http://dl-cdn.alpinelinux.org/alpine/edge/testing hub
 

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,10 @@ inputs:
     description: 'Prefix to be used for sync branches'
     required: false
     default: 'up'
+  denoise_message:
+    description: 'In case source is inside the same repo - the GHA runs of the opened PR may pollute the original commit-s status. Setting this enables a try to auto-merge the base branch - but if unsuccessfull falls back to add a technical commit commit message with the given message'
+    required: false
+    default: ''
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/action.yml
+++ b/action.yml
@@ -32,10 +32,8 @@ inputs:
     required: false
     default: 'false'
 runs:
-  using: 'composite'
-  steps:
-    - run: $GITHUB_ACTION_PATH/entrypoint.sh
-      shell: bash
+  using: 'docker'
+  image: 'Dockerfile'
 branding:
   icon: git-merge
   color: yellow

--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,10 @@ inputs:
     description: 'In case source is inside the same repo - the GHA runs of the opened PR may pollute the original commit-s status. Setting this enables a try to auto-merge the base branch - but if unsuccessfull falls back to add a technical commit commit message with the given message'
     required: false
     default: ''
+  cleanup:
+    description: 'Cleans up open PR for which the base was already merged'
+    required: false
+    default: 'false'
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/action.yml
+++ b/action.yml
@@ -32,8 +32,10 @@ inputs:
     required: false
     default: 'false'
 runs:
-  using: 'docker'
-  image: 'Dockerfile'
+  using: 'composite'
+  steps:
+    - run: $GITHUB_ACTION_PATH/entrypoint.sh
+      shell: bash
 branding:
   icon: git-merge
   color: yellow

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -68,7 +68,7 @@ fi
 if [ "${INPUT_CLEANUP}" == "true" ];then
   echo "@ cleanup"
   for PR_NUMBER in $(gh pr list -l "${INPUT_PR_LABELS}" -S "in:title ${INPUT_PR_TITLE}" --json number -q '.[].number'); do
-     pr_sha=$(gh pr view $PR_NUMBER --json title -q '.title' | sed 's/.*://')
+     pr_sha=$(gh pr view $PR_NUMBER --json title -q '.title' | sed 's/.*://'| tr -d ' ')
      echo "cleanup $PR_NUMBER; sha: $pr_sha"
      if git log --oneline "$pr_sha" ;then
        base=$(git merge-base ${INPUT_BRANCH} ${pr_sha})

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -67,6 +67,7 @@ fi
 
 if [ "${INPUT_CLEANUP}" == "true" ];then
   echo "@ cleanup"
+  gh pr list -l "${INPUT_PR_LABELS}" -S "in:title ${INPUT_PR_TITLE}" --json number -q '.[].number'
   for PR_NUMBER in gh pr list -l "${INPUT_PR_LABELS}" -S "in:title ${INPUT_PR_TITLE}" --json number -q '.[].number'; do
      pr_sha=$(gh pr view $PR_NUMBER --json title -q '.title' | sed 's/.*://')
      echo "cleanup $PR_NUMBER; sha: $pr_sha"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -71,7 +71,7 @@ if [ "${INPUT_CLEANUP}" == "true" ];then
      pr_sha="${gh pr view $PR_NUMBER --json title -q '.title' | sed 's/.*://'}"
      echo "cleanup $PR_NUMBER; sha: $pr_sha"
      if git log --oneline "$pr_sha" ;then
-       base="${git merge-base ${INPUT_BRANCH} ${pr_sha}"
+       base="${git merge-base ${INPUT_BRANCH} ${pr_sha}}"
        if [ "$base" == "$pr_sha" ]; then
          gh pr close "$PR_NUMBER" --comment "Content was already merged." --delete-branch
        fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -63,7 +63,6 @@ if [[ "${up_to_date}" -eq 0 ]]; then
   fi
 else
   echo "Branch up-to-date"
-  exit 0
 fi
 
 if [ "${INPUT_CLEANUP}" == "true" ];then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -59,7 +59,7 @@ if [[ "${up_to_date}" -eq 0 ]]; then
     exit 0
   else
     git_cmd git push -u origin "${pr_branch}"
-    git_cmd hub pull-request -b "${INPUT_BRANCH}" -h "${pr_branch}" -l "${INPUT_PR_LABELS}" -a "${GITHUB_ACTOR}" -m "\"${INPUT_PR_TITLE}: ${last_sha}\""
+    git_cmd hub pull-request -b "${INPUT_BRANCH}" -h "${pr_branch}" -l "${INPUT_PR_LABELS}" -m "\"${INPUT_PR_TITLE}: ${last_sha}\""
   fi
 else
   echo "Branch up-to-date"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -67,7 +67,7 @@ fi
 
 if [ "${INPUT_CLEANUP}" == "true" ];then
   echo "@ cleanup"
-  for PR_NUMBER in gh pr list -l "${INPUT_PR_LABELS}" -S "in:title ${INPUT_PR_TITLE}" --json number -q '.[].number); do
+  for PR_NUMBER in gh pr list -l "${INPUT_PR_LABELS}" -S "in:title ${INPUT_PR_TITLE}" --json number -q '.[].number'; do
      pr_sha="${gh pr view $PR_NUMBER --json title -q '.title' | sed 's/.*://'}"
      echo "cleanup $PR_NUMBER; sha: $pr_sha"
      if git log --oneline "$pr_sha" ;then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -67,6 +67,7 @@ else
 fi
 
 if [ "${INPUT_CLEANUP}" == "true" ];then
+  echo "@ cleanup"
   for PR_NUMBER in gh pr list -l "${INPUT_PR_LABELS}" -S "in:title ${INPUT_PR_TITLE}" --json number -q '.[].number); do
      pr_sha="${gh pr view $PR_NUMBER --json title -q '.title' | sed 's/.*://'}"
      echo "cleanup $PR_NUMBER; sha: $pr_sha"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,7 @@
 #!/bin/sh -l
 
+set
+
 git_setup() {
   cat <<- EOF > $HOME/.netrc
     machine github.com

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -76,5 +76,5 @@ if [ "${INPUT_CLEANUP}" == "true" ];then
          gh pr close "$PR_NUMBER" --comment "Content was already merged." --delete-branch
        fi
      fi
-  fi
+  done
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -73,8 +73,7 @@ if [ "${INPUT_CLEANUP}" == "true" ];then
      if git log -n1 --oneline "$pr_sha" ;then
        base=$(git merge-base origin/${INPUT_BRANCH} ${pr_sha})
        if [ "$base" == "$pr_sha" ]; then
-         echo git_cmd gh pr close "$PR_NUMBER" --comment "Content was already merged." --delete-branch
-         git_cmd gh pr close "$PR_NUMBER" --comment "Content was already merged." --delete-branch
+         gh pr close "$PR_NUMBER" --comment "Content was already merged." --delete-branch
        fi
      fi
   done

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,8 +24,6 @@ git_cmd() {
   fi
 }
 
-[ "$ACTIONS_RUNNER_DEBUG" == "true" ] && set -x
-
 git_setup
 git remote add upstream ${INPUT_UPSTREAM}
 git fetch --all

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,13 +25,13 @@ git_cmd() {
 }
 
 git_setup
-git_cmd git remote add upstream ${INPUT_UPSTREAM}
-git_cmd git fetch --all
+git remote add upstream ${INPUT_UPSTREAM}
+git fetch --all
 
 last_sha=$(git rev-list -1 upstream/${INPUT_UPSTREAM_BRANCH})
 echo "Last commited SHA: ${last_sha}"
 
-up_to_date=$(git_cmd git rev-list origin/${INPUT_BRANCH} | grep ${last_sha} | wc -l)
+up_to_date=$(git rev-list origin/${INPUT_BRANCH} | grep ${last_sha} | wc -l)
 pr_branch="${INPUT_SYNC_BRANCH_PREFIX}-${last_sha}"
 
 if [[ "${up_to_date}" -eq 0 ]]; then
@@ -49,7 +49,7 @@ if [[ "${up_to_date}" -eq 0 ]]; then
   fi
 
   hub pr list
-  pr_exists=$(git_cmd hub pr list | grep ${last_sha} | wc -l)
+  pr_exists=$(hub pr list | grep ${last_sha} | wc -l)
 
   if [[ "${pr_exists}" -gt 0 ]]; then
     echo "PR Already exists!!!"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -50,6 +50,7 @@ if [[ "${up_to_date}" -eq 0 ]]; then
     fi
   fi
 
+  git remote remove upstream
   hub pr list
   pr_exists=$(hub pr list | grep ${last_sha} | wc -l)
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -68,12 +68,12 @@ fi
 if [ "${INPUT_CLEANUP}" == "true" ];then
   echo "@ cleanup"
   for PR_NUMBER in gh pr list -l "${INPUT_PR_LABELS}" -S "in:title ${INPUT_PR_TITLE}" --json number -q '.[].number'; do
-     pr_sha="${gh pr view $PR_NUMBER --json title -q '.title' | sed 's/.*://'}"
+     pr_sha=$(gh pr view $PR_NUMBER --json title -q '.title' | sed 's/.*://')
      echo "cleanup $PR_NUMBER; sha: $pr_sha"
      if git log --oneline "$pr_sha" ;then
-       base="${git merge-base ${INPUT_BRANCH} ${pr_sha}}"
+       base=$(git merge-base ${INPUT_BRANCH} ${pr_sha})
        if [ "$base" == "$pr_sha" ]; then
-         gh pr close "$PR_NUMBER" --comment "Content was already merged." --delete-branch
+         git_cmd gh pr close "$PR_NUMBER" --comment "Content was already merged." --delete-branch
        fi
      fi
   done

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,7 +24,7 @@ git_cmd() {
   fi
 }
 
-[ "$ACTIONS_STEP_DEBUG" == "true" ] && set -x
+[ "$ACTIONS_RUNNER_DEBUG" == "true" ] && set -x
 
 git_setup
 git remote add upstream ${INPUT_UPSTREAM}
@@ -73,6 +73,7 @@ if [ "${INPUT_CLEANUP}" == "true" ];then
      if git log -n1 --oneline "$pr_sha" ;then
        base=$(git merge-base origin/${INPUT_BRANCH} ${pr_sha})
        if [ "$base" == "$pr_sha" ]; then
+         echo git_cmd gh pr close "$PR_NUMBER" --comment "Content was already merged." --delete-branch
          git_cmd gh pr close "$PR_NUMBER" --comment "Content was already merged." --delete-branch
        fi
      fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -28,7 +28,7 @@ git_setup
 git_cmd git remote add upstream ${INPUT_UPSTREAM}
 git_cmd git fetch --all
 
-last_sha=$(git_cmd git rev-list -1 upstream/${INPUT_UPSTREAM_BRANCH})
+last_sha=$(git rev-list -1 upstream/${INPUT_UPSTREAM_BRANCH})
 echo "Last commited SHA: ${last_sha}"
 
 up_to_date=$(git_cmd git rev-list origin/${INPUT_BRANCH} | grep ${last_sha} | wc -l)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,5 @@
 #!/bin/sh -l
 
-set
-
 git_setup() {
   cat <<- EOF > $HOME/.netrc
     machine github.com
@@ -67,7 +65,6 @@ else
   echo "Branch up-to-date"
 fi
 
-alias gh=hub
 if [ "${INPUT_CLEANUP}" == "true" ];then
   echo "@ cleanup"
   gh pr list -l "${INPUT_PR_LABELS}" -S "in:title ${INPUT_PR_TITLE}" --json number -q '.[].number'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,8 +24,9 @@ git_cmd() {
   fi
 }
 
+[ "$ACTIONS_STEP_DEBUG" == "true" ] && set -x
+
 git_setup
-set -x
 git remote add upstream ${INPUT_UPSTREAM}
 git fetch --all
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -65,3 +65,16 @@ else
   echo "Branch up-to-date"
   exit 0
 fi
+
+if [ "${INPUT_CLEANUP}" == "true" ];then
+  for PR_NUMBER in gh pr list -l "${INPUT_PR_LABELS}" -S "in:title ${INPUT_PR_TITLE}" --json number -q '.[].number); do
+     pr_sha="${gh pr view $PR_NUMBER --json title -q '.title' | sed 's/.*://'}"
+     echo "cleanup $PR_NUMBER; sha: $pr_sha"
+     if git log --oneline "$pr_sha" ;then
+       base="${git merge-base ${INPUT_BRANCH} ${pr_sha}"
+       if [ "$base" == "$pr_sha" ]; then
+         gh pr close "$PR_NUMBER" --comment "Content was already merged." --delete-branch
+       fi
+     fi
+  fi
+fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -67,8 +67,7 @@ fi
 
 if [ "${INPUT_CLEANUP}" == "true" ];then
   echo "@ cleanup"
-  gh pr list -l "${INPUT_PR_LABELS}" -S "in:title ${INPUT_PR_TITLE}" --json number -q '.[].number'
-  for PR_NUMBER in gh pr list -l "${INPUT_PR_LABELS}" -S "in:title ${INPUT_PR_TITLE}" --json number -q '.[].number'; do
+  for PR_NUMBER in $(gh pr list -l "${INPUT_PR_LABELS}" -S "in:title ${INPUT_PR_TITLE}" --json number -q '.[].number'); do
      pr_sha=$(gh pr view $PR_NUMBER --json title -q '.title' | sed 's/.*://')
      echo "cleanup $PR_NUMBER; sha: $pr_sha"
      if git log --oneline "$pr_sha" ;then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -70,8 +70,8 @@ if [ "${INPUT_CLEANUP}" == "true" ];then
   for PR_NUMBER in $(gh pr list -l "${INPUT_PR_LABELS}" -S "in:title ${INPUT_PR_TITLE}" --json number -q '.[].number'); do
      pr_sha=$(gh pr view $PR_NUMBER --json title -q '.title' | sed 's/.*://'| tr -d ' ')
      echo "cleanup $PR_NUMBER; sha: $pr_sha"
-     if git log --oneline "$pr_sha" ;then
-       base=$(git merge-base ${INPUT_BRANCH} ${pr_sha})
+     if git log -n1 --oneline "$pr_sha" ;then
+       base=$(git merge-base origin/${INPUT_BRANCH} ${pr_sha})
        if [ "$base" == "$pr_sha" ]; then
          git_cmd gh pr close "$PR_NUMBER" --comment "Content was already merged." --delete-branch
        fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -65,6 +65,7 @@ else
   echo "Branch up-to-date"
 fi
 
+alias gh=hub
 if [ "${INPUT_CLEANUP}" == "true" ];then
   echo "@ cleanup"
   gh pr list -l "${INPUT_PR_LABELS}" -S "in:title ${INPUT_PR_TITLE}" --json number -q '.[].number'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,9 +18,9 @@ EOF
 
 git_cmd() {
   if [[ "${DRY_RUN:-false}" == "true" ]]; then
-    echo $@
+    echo "$@"
   else
-    eval $@
+    eval "$@"
   fi
 }
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,6 +25,7 @@ git_cmd() {
 }
 
 git_setup
+set -x
 git remote add upstream ${INPUT_UPSTREAM}
 git fetch --all
 


### PR DESCRIPTION
Setting `denoise_message` enables a try of the base branch ; if unsuccessfull creates an empty commit.

This is needed in case upstream is inside the same repo

setting `cleanup=true` enables to go thru all open PRs labeled saimilarily - and closes them if they were already merged into the target branch